### PR TITLE
Add interval parser for Japanese range expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# jp-range
+
+A small utility to parse Japanese numeric range expressions.
+The returned `Interval` is a [Pydantic](https://docs.pydantic.dev/) model.
+
+## Usage
+
+```python
+from jp_range import parse_jp_range
+
+interval = parse_jp_range("40以上50未満")
+print(interval)
+print(interval.contains(45))  # True
+```
+
+Supported expressions include:
+
+- ``"20から30"`` – inclusive 20 to 30
+- ``"30以上40以下"`` – inclusive 30 to 40
+- ``"40以上50未満"`` – 40 to under 50
+- ``"50より上"`` – greater than 50
+- ``"60より下"`` – less than 60

--- a/src/jp_range/__init__.py
+++ b/src/jp_range/__init__.py
@@ -1,0 +1,5 @@
+"""Utilities for parsing Japanese numeric ranges."""
+
+from .interval import Interval, parse_jp_range
+
+__all__ = ["Interval", "parse_jp_range"]

--- a/src/jp_range/interval.py
+++ b/src/jp_range/interval.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from typing import Optional
+import re
+
+from pydantic import BaseModel
+
+
+class Interval(BaseModel):
+    """Represents a numeric interval."""
+
+    lower: Optional[float] = None
+    upper: Optional[float] = None
+    lower_inclusive: bool = False
+    upper_inclusive: bool = False
+
+    def __str__(self) -> str:
+        lower_bracket = "[" if self.lower_inclusive else "("
+        upper_bracket = "]" if self.upper_inclusive else ")"
+        lower_val = str(self.lower) if self.lower is not None else "-inf"
+        upper_val = str(self.upper) if self.upper is not None else "inf"
+        return f"{lower_bracket}{lower_val}, {upper_val}{upper_bracket}"
+
+    def contains(self, value: float) -> bool:
+        """Return True if the value is inside this interval."""
+        if self.lower is not None:
+            if self.lower_inclusive:
+                if value < self.lower:
+                    return False
+            else:
+                if value <= self.lower:
+                    return False
+        if self.upper is not None:
+            if self.upper_inclusive:
+                if value > self.upper:
+                    return False
+            else:
+                if value >= self.upper:
+                    return False
+        return True
+
+
+# Precompiled patterns for typical Japanese range expressions
+_PATTERNS: list[tuple[re.Pattern[str], callable]] = [
+    (re.compile(r"^(\d+)から(\d+)$"),
+     lambda m: Interval(
+         lower=int(m.group(1)),
+         upper=int(m.group(2)),
+         lower_inclusive=True,
+         upper_inclusive=True,
+     )),
+    (re.compile(r"^(\d+)以上(\d+)以下$"),
+     lambda m: Interval(
+         lower=int(m.group(1)),
+         upper=int(m.group(2)),
+         lower_inclusive=True,
+         upper_inclusive=True,
+     )),
+    (re.compile(r"^(\d+)以上(\d+)未満$"),
+     lambda m: Interval(
+         lower=int(m.group(1)),
+         upper=int(m.group(2)),
+         lower_inclusive=True,
+         upper_inclusive=False,
+     )),
+    (re.compile(r"^(\d+)より上$"),
+     lambda m: Interval(
+         lower=int(m.group(1)),
+         upper=None,
+         lower_inclusive=False,
+         upper_inclusive=False,
+     )),
+    (re.compile(r"^(\d+)より下$"),
+     lambda m: Interval(
+         lower=None,
+         upper=int(m.group(1)),
+         lower_inclusive=False,
+         upper_inclusive=False,
+     )),
+]
+
+
+def parse_jp_range(text: str) -> Interval:
+    """Parse a Japanese numeric range expression into an :class:`Interval`.
+
+    Parameters
+    ----------
+    text:
+        Japanese range expression such as ``"20から30"`` or ``"50より上"``.
+
+    Returns
+    -------
+    Interval
+        Parsed interval representation.
+
+    Raises
+    ------
+    ValueError
+        If the text cannot be parsed.
+    """
+    text = text.strip()
+    for pattern, builder in _PATTERNS:
+        m = pattern.fullmatch(text)
+        if m:
+            return builder(m)
+    raise ValueError(f"Cannot parse range: {text}")

--- a/tests/test_interval.py
+++ b/tests/test_interval.py
@@ -1,0 +1,51 @@
+from jp_range import Interval, parse_jp_range
+
+
+def test_parse_inclusive_range():
+    r = parse_jp_range("20から30")
+    assert r.lower == 20
+    assert r.upper == 30
+    assert r.lower_inclusive is True
+    assert r.upper_inclusive is True
+    assert r.contains(20)
+    assert r.contains(25)
+    assert r.contains(30)
+    assert not r.contains(19)
+    assert not r.contains(31)
+
+
+def test_parse_ge_le():
+    r = parse_jp_range("30以上40以下")
+    assert r.lower == 30
+    assert r.upper == 40
+    assert r.lower_inclusive is True
+    assert r.upper_inclusive is True
+
+
+def test_parse_ge_lt():
+    r = parse_jp_range("40以上50未満")
+    assert r.lower == 40
+    assert r.upper == 50
+    assert r.lower_inclusive is True
+    assert r.upper_inclusive is False
+    assert r.contains(40)
+    assert r.contains(49.9)
+    assert not r.contains(50)
+
+
+def test_greater_than():
+    r = parse_jp_range("50より上")
+    assert r.lower == 50
+    assert r.upper is None
+    assert not r.lower_inclusive
+    assert r.contains(51)
+    assert not r.contains(50)
+
+
+def test_less_than():
+    r = parse_jp_range("60より下")
+    assert r.upper == 60
+    assert r.lower is None
+    assert not r.upper_inclusive
+    assert r.contains(59)
+    assert not r.contains(60)


### PR DESCRIPTION
## Summary
- implement `Interval` dataclass with contain check and string representation
- implement `parse_jp_range` to parse Japanese range expressions
- expose functions in package init
- add usage example in README
- provide tests for different patterns

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683da03a7d48832784fb205ec843ad0c