### PR TITLE
Add neologdn normalization and whitespace cleanup

### DIFF
--- a/src/jp_range/interval.py
+++ b/src/jp_range/interval.py
@@ -4,6 +4,7 @@ from typing import Optional
 import re
 
 from pydantic import BaseModel
+import neologdn
 
 
 class Interval(BaseModel):
@@ -98,6 +99,8 @@ def parse_jp_range(text: str) -> Interval:
     ValueError
         If the text cannot be parsed.
     """
+    text = neologdn.normalize(text)
+    text = re.sub(r"\s+", "", text)
     text = text.strip()
     for pattern, builder in _PATTERNS:
         m = pattern.fullmatch(text)

--- a/tests/test_interval.py
+++ b/tests/test_interval.py
@@ -49,3 +49,11 @@ def test_less_than():
     assert not r.upper_inclusive
     assert r.contains(59)
     assert not r.contains(60)
+
+
+def test_normalize_and_remove_spaces():
+    r = parse_jp_range("\u3000４０  以上\u3000５０ 未満\u3000")
+    assert r.lower == 40
+    assert r.upper == 50
+    assert r.lower_inclusive is True
+    assert r.upper_inclusive is False


### PR DESCRIPTION
## Summary
- normalize range expressions with `neologdn`
- remove unnecessary whitespace before parsing
- test for fullwidth digits and spaces

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jp_range')*

------
https://chatgpt.com/codex/tasks/task_e_683da2f506ec8327948489da669dddf2