### PR TITLE
Implement extensive JP range parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,10 @@ print(interval.contains(45))  # True
 Supported expressions include:
 
 - ``"20から30"`` – inclusive 20 to 30
+- ``"20〜30"`` – inclusive 20 to 30 using a tilde connector
 - ``"30以上40以下"`` – inclusive 30 to 40
 - ``"40以上50未満"`` – 40 to under 50
+- ``"70超90以下"`` – greater than 70 and up to 90
 - ``"50より上"`` – greater than 50
 - ``"60より下"`` – less than 60
+- ``"90前後"`` – roughly around 90 (5% margin)

--- a/tests/test_interval.py
+++ b/tests/test_interval.py
@@ -57,3 +57,45 @@ def test_normalize_and_remove_spaces():
     assert r.upper == 50
     assert r.lower_inclusive is True
     assert r.upper_inclusive is False
+
+
+def test_tilde_connector():
+    r = parse_jp_range("20〜30")
+    assert r.lower == 20
+    assert r.upper == 30
+
+
+def test_exclusive_inclusive():
+    r = parse_jp_range("70超90以下")
+    assert r.lower == 70
+    assert r.upper == 90
+    assert not r.lower_inclusive
+    assert r.upper_inclusive
+
+
+def test_both_exclusive():
+    r = parse_jp_range("10を超え20未満")
+    assert not r.lower_inclusive
+    assert not r.upper_inclusive
+    assert r.contains(19.9)
+    assert not r.contains(10)
+
+
+def test_single_bound():
+    r = parse_jp_range("80以上")
+    assert r.lower == 80
+    assert r.upper is None
+    assert r.lower_inclusive
+
+
+def test_upper_bound():
+    r = parse_jp_range("100未満")
+    assert r.upper == 100
+    assert r.lower is None
+    assert not r.upper_inclusive
+
+
+def test_approx_range():
+    r = parse_jp_range("90前後")
+    assert round(r.lower, 1) == 85.5
+    assert round(r.upper, 1) == 94.5


### PR DESCRIPTION
## Summary
- support many common Japanese numeric range patterns
- normalize full-width digits and connectors
- handle approximate ranges (e.g. 前後)
- expand tests

## Testing
- `PYTHONPATH=src pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_683da4c155708327bd1f7231678923db