### PR TITLE
Add pandas utilities and improve range parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,15 @@ The returned `Interval` is a [Pydantic](https://docs.pydantic.dev/) model.
 ## Usage
 
 ```python
-from jp_range import parse_jp_range
+from pandas import Series
+from jp_range import parse, parse_series
 
-interval = parse_jp_range("40以上50未満")
+interval = parse("40以上50未満")
 print(interval)
 print(interval.contains(45))  # True
+
+s = Series(["20～30", "50超", "未満100"])
+parse_series(s)
 ```
 
 Supported expressions include:

--- a/src/jp_range/__init__.py
+++ b/src/jp_range/__init__.py
@@ -1,6 +1,37 @@
 """Utilities for parsing Japanese numeric ranges."""
 
+from typing import Union
+
+import pandas as pd
+
 from .interval import Interval
 from .parser import parse_jp_range
 
-__all__ = ["Interval", "parse_jp_range"]
+
+def parse(text: str) -> Interval:
+    """Alias for :func:`parse_jp_range`."""
+
+    return parse_jp_range(text)
+
+
+def parse_series(
+    obj: Union[pd.Series, pd.DataFrame]
+) -> Union[pd.Series, pd.DataFrame]:
+    """Parse a ``Series`` or ``DataFrame`` of textual ranges.
+
+    Each element is parsed using :func:`parse_jp_range` and replaced
+    with an :class:`Interval` instance. Non-string values are left as is.
+    """
+
+    if isinstance(obj, pd.Series):
+        return obj.apply(
+            lambda x: parse_jp_range(x) if isinstance(x, str) else x
+        )
+    if isinstance(obj, pd.DataFrame):
+        return obj.applymap(
+            lambda x: parse_jp_range(x) if isinstance(x, str) else x
+        )
+    raise TypeError("parse_series expects a pandas Series or DataFrame")
+
+
+__all__ = ["Interval", "parse_jp_range", "parse", "parse_series"]

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -1,0 +1,26 @@
+from pandas import Series, DataFrame
+
+from jp_range import Interval, parse, parse_jp_range, parse_series
+
+
+def test_parse_alias():
+    r = parse("30以上40未満")
+    expected = parse_jp_range("30以上40未満")
+    assert r == expected
+
+
+def test_parse_series_with_series():
+    s = Series(["20～30", "50超", "未満100"])
+    result = parse_series(s)
+    assert isinstance(result, Series)
+    assert isinstance(result.iloc[0], Interval)
+    assert result.iloc[0].lower == 20
+    assert result.iloc[1].lower == 50
+    assert result.iloc[2].upper == 100
+
+
+def test_parse_series_with_dataframe():
+    df = DataFrame({"range": ["20～30", "50超"]})
+    result = parse_series(df)
+    assert isinstance(result.loc[0, "range"], Interval)
+    assert result.loc[0, "range"].lower == 20


### PR DESCRIPTION
## Summary
- support user-facing `parse` and `parse_series` helpers
- allow tilde ranges by replacing symbols before normalization
- accept prefix form such as `未満100`
- update README usage
- add tests for pandas helpers

## Testing
- `PYTHONPATH=src:.venv/lib/python3.12/site-packages pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683daa303cac832786381bd9e23eefbb