### PR TITLE
Improve range parser to allow connectors

### DIFF
--- a/src/jp_range/parser.py
+++ b/src/jp_range/parser.py
@@ -124,54 +124,54 @@ _PATTERNS: list[tuple[re.Pattern[str], Callable[[re.Match[str]], Interval]]] = [
         re.compile(rf"^{_NUM}と{_NUM}の?間$"),
         _range_builder(False, False),
     ),
-    # A以上B以下
+    # A以上B以下 (allow connectors like commas or words between bounds)
     (
-        re.compile(rf"^{_NUM}以上{_NUM}以下$"),
+        re.compile(rf"^{_NUM}以上\D*{_NUM}以下$"),
         _range_builder(True, True),
     ),
     # A以上B未満
     (
-        re.compile(rf"^{_NUM}以上{_NUM}未満$"),
+        re.compile(rf"^{_NUM}以上\D*{_NUM}未満$"),
         _range_builder(True, False),
     ),
     # A超B以下
     (
-        re.compile(rf"^{_NUM}超{_NUM}以下$"),
+        re.compile(rf"^{_NUM}超\D*{_NUM}以下$"),
         _range_builder(False, True),
     ),
     # A超B未満
     (
-        re.compile(rf"^{_NUM}超{_NUM}未満$"),
+        re.compile(rf"^{_NUM}超\D*{_NUM}未満$"),
         _range_builder(False, False),
     ),
     # Aを超えB以下
     (
-        re.compile(rf"^{_NUM}を?超え{_NUM}以下$"),
+        re.compile(rf"^{_NUM}を?超え\D*{_NUM}以下$"),
         _range_builder(False, True),
     ),
     # Aを超えB未満
     (
-        re.compile(rf"^{_NUM}を?超え{_NUM}未満$"),
+        re.compile(rf"^{_NUM}を?超え\D*{_NUM}未満$"),
         _range_builder(False, False),
     ),
     # Aを上回りB以下
     (
-        re.compile(rf"^{_NUM}を?上回り{_NUM}以下$"),
+        re.compile(rf"^{_NUM}を?上回り\D*{_NUM}以下$"),
         _range_builder(False, True),
     ),
     # Aを上回りB未満
     (
-        re.compile(rf"^{_NUM}を?上回り{_NUM}未満$"),
+        re.compile(rf"^{_NUM}を?上回り\D*{_NUM}未満$"),
         _range_builder(False, False),
     ),
     # Aより大きいB以下
     (
-        re.compile(rf"^{_NUM}より大きい{_NUM}以下$"),
+        re.compile(rf"^{_NUM}より大きい\D*{_NUM}以下$"),
         _range_builder(False, True),
     ),
     # Aより大きいB未満
     (
-        re.compile(rf"^{_NUM}より大きい{_NUM}未満$"),
+        re.compile(rf"^{_NUM}より大きい\D*{_NUM}未満$"),
         _range_builder(False, False),
     ),
     # Lower bound inclusive

--- a/tests/test_interval.py
+++ b/tests/test_interval.py
@@ -22,6 +22,22 @@ def test_parse_ge_le():
     assert r.upper_inclusive is True
 
 
+def test_parse_ge_le_with_connector():
+    r = parse_jp_range("30以上,40以下")
+    assert r.lower == 30
+    assert r.upper == 40
+    assert r.lower_inclusive is True
+    assert r.upper_inclusive is True
+
+
+def test_parse_ge_le_with_word_connector():
+    r = parse_jp_range("30以上そして40以下")
+    assert r.lower == 30
+    assert r.upper == 40
+    assert r.lower_inclusive is True
+    assert r.upper_inclusive is True
+
+
 def test_parse_ge_lt():
     r = parse_jp_range("40以上50未満")
     assert r.lower == 40


### PR DESCRIPTION
## Summary
- allow any non-digit characters between numeric bounds
- test parsing ranges with commas or words between bounds

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jp_range', pandas)*

------
https://chatgpt.com/codex/tasks/task_e_683dacad3730832797cb070e2d921352