### PR TITLE
Add generic interval notation parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # jp-range
 
-jp-range is a small library for parsing Japanese numeric range expressions. It returns an `Interval` object implemented with [Pydantic](https://docs.pydantic.dev/).
+jp-range is a small library for parsing Japanese numeric range expressions. It returns an `Interval` object implemented with [Pydantic](https://docs.pydantic.dev/) or ``None`` when parsing fails.
 
 ## Installation
 
@@ -53,5 +53,6 @@ result = parse_series(s)
 - `"50より上"` – greater than 50
 - `"60より下"` – less than 60
 - `"90前後"` – roughly around 90 (5% margin)
+- `"(2,3]"` – standard interval notation
 
-`parse_jp_range` raises `ValueError` if the expression cannot be parsed.
+`parse_jp_range` returns ``None`` if the expression cannot be parsed.

--- a/src/jp_range/__init__.py
+++ b/src/jp_range/__init__.py
@@ -8,7 +8,7 @@ from .interval import Interval
 from .parser import parse_jp_range
 
 
-def parse(text: str) -> Interval:
+def parse(text: str) -> Interval | None:
     """Alias for :func:`parse_jp_range`."""
 
     return parse_jp_range(text)
@@ -20,7 +20,8 @@ def parse_series(
     """Parse a ``Series`` or ``DataFrame`` of textual ranges.
 
     Each element is parsed using :func:`parse_jp_range` and replaced
-    with an :class:`Interval` instance. Non-string values are left as is.
+    with an :class:`Interval` instance or ``None`` when parsing fails.
+    Non-string values are left as is.
     """
 
     if isinstance(obj, pd.Series):

--- a/tests/test_interval.py
+++ b/tests/test_interval.py
@@ -115,3 +115,16 @@ def test_approx_range():
     r = parse_jp_range("90前後")
     assert round(r.lower, 1) == 85.5
     assert round(r.upper, 1) == 94.5
+
+
+def test_interval_notation():
+    r = parse_jp_range("(2,3]")
+    assert r.lower == 2
+    assert r.upper == 3
+    assert not r.lower_inclusive
+    assert r.upper_inclusive
+
+
+def test_parse_failure_returns_none():
+    r = parse_jp_range("unknown")
+    assert r is None


### PR DESCRIPTION
## Summary
- support standard interval notation like `(2,3]`
- return `None` instead of raising an error when parsing fails
- update docs to mention new behavior
- add tests for interval notation and failure case

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jp_range')*

------
https://chatgpt.com/codex/tasks/task_e_683dc757e8e48327a92b83c6eeb567e9