### PR TITLE
Implement pandas Interval conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ from jp_range import parse_series
 
 s = Series(["20～30", "50超", "未満100"])
 result = parse_series(s)
-# result is a Series of Interval objects
+# result is a Series of pandas.Interval objects
 ```
 
 ### Supported expressions

--- a/src/jp_range/__init__.py
+++ b/src/jp_range/__init__.py
@@ -20,18 +20,20 @@ def parse_series(
     """Parse a ``Series`` or ``DataFrame`` of textual ranges.
 
     Each element is parsed using :func:`parse_jp_range` and replaced
-    with an :class:`Interval` instance or ``None`` when parsing fails.
+    with a :class:`pandas.Interval` instance or ``None`` when parsing fails.
     Non-string values are left as is.
     """
 
+    def _convert(val: object):
+        if isinstance(val, str):
+            r = parse_jp_range(val)
+            return r.to_pd_interval() if r is not None else None
+        return val
+
     if isinstance(obj, pd.Series):
-        return obj.apply(
-            lambda x: parse_jp_range(x) if isinstance(x, str) else x
-        )
+        return obj.apply(_convert)
     if isinstance(obj, pd.DataFrame):
-        return obj.applymap(
-            lambda x: parse_jp_range(x) if isinstance(x, str) else x
-        )
+        return obj.applymap(_convert)
     raise TypeError("parse_series expects a pandas Series or DataFrame")
 
 

--- a/src/jp_range/interval.py
+++ b/src/jp_range/interval.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Optional
 
+import pandas as pd
+
 from pydantic import BaseModel
 
 
@@ -37,3 +39,17 @@ class Interval(BaseModel):
                 if value >= self.upper:
                     return False
         return True
+
+    def to_pd_interval(self) -> pd.Interval:
+        """Return a :class:`pandas.Interval` representation of this interval."""
+        left = self.lower if self.lower is not None else float("-inf")
+        right = self.upper if self.upper is not None else float("inf")
+        if self.lower_inclusive and self.upper_inclusive:
+            closed = "both"
+        elif self.lower_inclusive:
+            closed = "left"
+        elif self.upper_inclusive:
+            closed = "right"
+        else:
+            closed = "neither"
+        return pd.Interval(left, right, closed=closed)

--- a/tests/test_interval.py
+++ b/tests/test_interval.py
@@ -1,3 +1,5 @@
+import pandas as pd
+
 from jp_range import Interval, parse_jp_range
 
 
@@ -128,3 +130,12 @@ def test_interval_notation():
 def test_parse_failure_returns_none():
     r = parse_jp_range("unknown")
     assert r is None
+
+
+def test_to_pd_interval():
+    interval = Interval(lower=1, upper=3, lower_inclusive=True, upper_inclusive=False)
+    pd_interval = interval.to_pd_interval()
+    assert isinstance(pd_interval, pd.Interval)
+    assert pd_interval.left == 1
+    assert pd_interval.right == 3
+    assert pd_interval.closed == "left"

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -1,4 +1,4 @@
-from pandas import Series, DataFrame
+from pandas import Series, DataFrame, Interval as PdInterval
 
 from jp_range import Interval, parse, parse_jp_range, parse_series
 
@@ -13,14 +13,15 @@ def test_parse_series_with_series():
     s = Series(["20～30", "50超", "未満100"])
     result = parse_series(s)
     assert isinstance(result, Series)
-    assert isinstance(result.iloc[0], Interval)
-    assert result.iloc[0].lower == 20
-    assert result.iloc[1].lower == 50
-    assert result.iloc[2].upper == 100
+    assert isinstance(result.iloc[0], PdInterval)
+    assert result.iloc[0].left == 20
+    assert result.iloc[1].left == 50
+    assert result.iloc[2].right == 100
 
 
 def test_parse_series_with_dataframe():
     df = DataFrame({"range": ["20～30", "50超"]})
     result = parse_series(df)
-    assert isinstance(result.loc[0, "range"], Interval)
-    assert result.loc[0, "range"].lower == 20
+    assert isinstance(result.loc[0, "range"], PdInterval)
+    assert result.loc[0, "range"].left == 20
+


### PR DESCRIPTION
## Summary
- add `Interval.to_pd_interval` to convert to pandas Interval
- convert values to pandas Interval in `parse_series`
- update docs with pandas Interval usage
- test pandas Interval output

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683e23bda5788327bca79ac53877a902