### PR TITLE
Fix interval notation parsing

### DIFF
--- a/src/jp_range/parser.py
+++ b/src/jp_range/parser.py
@@ -32,8 +32,6 @@ def _normalize(text: str) -> str:
             "―": "-",
             "‐": "-",
             "．": ".",
-            "，": "",
-            ",": "",
         }
     )
     return text.translate(table)


### PR DESCRIPTION
## Summary
- keep commas when normalizing Japanese range text

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683e253faa4083278991b4557331d2e4