### PR TITLE
Allow parsing numbers with units

### DIFF
--- a/src/jp_range/parser.py
+++ b/src/jp_range/parser.py
@@ -37,8 +37,10 @@ def _normalize(text: str) -> str:
     return text.translate(table)
 
 
-# Numeric pattern supporting optional decimal and sign
-_NUM = r"([-+]?\d+(?:\.\d+)?(?:e[-+]?\d+)?)"
+# Numeric pattern supporting optional decimal and sign with trailing units
+# Units such as "m" or "個" should not be captured as part of the numeric value
+# but may appear directly after the number.
+_NUM = r"([-+]?\d+(?:\.\d+)?(?:e[-+]?\d+)?)(?:[a-zA-Zぁ-んァ-ン一-龥]*)"
 
 
 def _f(num: str) -> float:

--- a/tests/test_interval.py
+++ b/tests/test_interval.py
@@ -106,6 +106,13 @@ def test_single_bound():
     assert r.lower_inclusive
 
 
+def test_single_bound_with_unit():
+    r = parse_jp_range("１０個以上")
+    assert r.lower == 10
+    assert r.upper is None
+    assert r.lower_inclusive
+
+
 def test_upper_bound():
     r = parse_jp_range("100未満")
     assert r.upper == 100
@@ -115,6 +122,12 @@ def test_upper_bound():
 
 def test_approx_range():
     r = parse_jp_range("90前後")
+    assert round(r.lower, 1) == 85.5
+    assert round(r.upper, 1) == 94.5
+
+
+def test_approx_with_unit():
+    r = parse_jp_range("90m程度")
     assert round(r.lower, 1) == 85.5
     assert round(r.upper, 1) == 94.5
 


### PR DESCRIPTION
## Summary
- support optional trailing units after numeric values
- add tests for expressions like `90m程度` and `１０個以上`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683e277336988327956d35d996ef120e