### PR TITLE
Support mixed max/lt pattern

### DIFF
--- a/src/jp_range/parser.py
+++ b/src/jp_range/parser.py
@@ -128,6 +128,16 @@ def _max_min(m: re.Match[str]) -> Interval:
     )
 
 
+def _max_lower_lt(m: re.Match[str]) -> Interval:
+    """Build Interval from patterns like '最大10、-5未満'."""
+    return Interval(
+        lower=_f(m.group(2)),
+        upper=_f(m.group(1)),
+        lower_inclusive=False,
+        upper_inclusive=True,
+    )
+
+
 # Precompiled patterns for various Japanese range expressions
 _PATTERNS: list[tuple[re.Pattern[str], Callable[[re.Match[str]], Interval]]] = [
     # Standard interval notation like "(2,3]" or "[1,5)"
@@ -154,6 +164,11 @@ _PATTERNS: list[tuple[re.Pattern[str], Callable[[re.Match[str]], Interval]]] = [
     (
         re.compile(rf"^(?:最大(?:値)?|大){_NUM}\D*(?:最小(?:値)?|小){_NUM}$"),
         _max_min,
+    ),
+    # 最大A、B未満
+    (
+        re.compile(rf"^(?:最大(?:値)?|大){_NUM}\D*{_NUM}未満$"),
+        _max_lower_lt,
     ),
     # A以上B以下 (allow connectors like commas or words between bounds)
     (

--- a/tests/test_interval.py
+++ b/tests/test_interval.py
@@ -162,6 +162,14 @@ def test_dai_sho():
     assert r.upper == 3
 
 
+def test_max_with_lt_mixed():
+    r = parse_jp_range("最大10,-5未満")
+    assert r.lower == -5
+    assert r.upper == 10
+    assert not r.lower_inclusive
+    assert r.upper_inclusive
+
+
 def test_parse_failure_returns_none():
     r = parse_jp_range("unknown")
     assert r is None


### PR DESCRIPTION
## Summary
- add _max_lower_lt builder and pattern to parse mixed max expressions like `最大10,-5未満`
- test `最大10,-5未満`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683e2cf4db8c83279a127fa2683611ac