### PR TITLE
Handle mixed bound expressions generically

### DIFF
--- a/tests/test_interval.py
+++ b/tests/test_interval.py
@@ -162,6 +162,28 @@ def test_dai_sho():
     assert r.upper == 3
 
 
+def test_max_with_lt_mixed():
+    r = parse_jp_range("最大10,-5未満")
+    assert r.lower == -5
+    assert r.upper == 10
+    assert not r.lower_inclusive
+    assert r.upper_inclusive
+
+
+def test_ge_with_min_mixed():
+    r = parse_jp_range("5以上、最小1")
+    assert r.lower == 5
+    assert r.upper is None
+    assert r.lower_inclusive
+
+
+def test_gt_with_small_mixed():
+    r = parse_jp_range("１００より上、小10")
+    assert r.lower == 100
+    assert r.upper is None
+    assert not r.lower_inclusive
+
+
 def test_parse_failure_returns_none():
     r = parse_jp_range("unknown")
     assert r is None


### PR DESCRIPTION
## Summary
- add `_single_max` and `_single_min` for standalone bound keywords
- register regex patterns for `最大A` and `最小B`
- enhance `parse_jp_range` to combine comma-separated parts
- support phrases like `5以上、最小1` and `１００より上、小10`
- test new mixed patterns

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683e2cf4db8c83279a127fa2683611ac