### PR TITLE
Add DataFrame column detection and update pandas helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Python 3.12 or later is required.
 - Supports inclusive and exclusive bounds (`以上`, `未満`, etc.)
 - Parses connectors such as `〜`, `-` and `から`
 - Handles single-sided bounds, approximate expressions (`90前後`) and `A±d` notation
-- Integrates with pandas via `parse_series` for `Series` and `DataFrame`
+- Integrates with pandas via `apply_parse` for `Series` and `DataFrame`
 
 ## Usage
 
@@ -36,10 +36,11 @@ print(interval.contains(45))  # True
 
 ```python
 from pandas import Series
-from jp_range import parse_series
+from jp_range import apply_parse
 
+# Convert Series of textual ranges to pandas.Interval
 s = Series(["20～30", "50超", "未満100"])
-result = parse_series(s)
+result = apply_parse(s)
 # result is a Series of pandas.Interval objects
 ```
 

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -1,6 +1,6 @@
 from pandas import Series, DataFrame, Interval as PdInterval
 
-from jp_range import Interval, parse, parse_jp_range, parse_series
+from jp_range import Interval, parse, parse_jp_range, apply_parse, detect_interval_columns
 
 
 def test_parse_alias():
@@ -9,9 +9,9 @@ def test_parse_alias():
     assert r == expected
 
 
-def test_parse_series_with_series():
+def test_apply_parse_with_series():
     s = Series(["20～30", "50超", "未満100"])
-    result = parse_series(s)
+    result = apply_parse(s)
     assert isinstance(result, Series)
     assert isinstance(result.iloc[0], PdInterval)
     assert result.iloc[0].left == 20
@@ -19,9 +19,26 @@ def test_parse_series_with_series():
     assert result.iloc[2].right == 100
 
 
-def test_parse_series_with_dataframe():
+def test_apply_parse_with_dataframe():
     df = DataFrame({"range": ["20～30", "50超"]})
-    result = parse_series(df)
+    result = apply_parse(df)
     assert isinstance(result.loc[0, "range"], PdInterval)
     assert result.loc[0, "range"].left == 20
+
+
+def test_apply_parse_with_columns():
+    df = DataFrame({"range": ["20～30", "50超"], "text": ["a", "b"]})
+    result = apply_parse(df, columns=["range"])
+    assert isinstance(result.loc[0, "range"], PdInterval)
+    assert result.loc[0, "text"] == "a"
+
+
+def test_detect_interval_columns():
+    df = DataFrame({
+        "a": ["20～30", "50超"],
+        "b": ["foo", "bar"],
+    })
+    cols = detect_interval_columns(df, threshold=0.5)
+    assert "a" in cols
+    assert "b" not in cols
 


### PR DESCRIPTION
## Summary
- rename `parse_series` to `apply_parse`
- allow specifying columns when applying parse to DataFrames
- add `detect_interval_columns` utility for DataFrames
- update README and tests for new API

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683e45975d08832787d113aaeeccbd89