### PR TITLE
Handle reversed Japanese range expressions

### DIFF
--- a/src/jp_range/parser.py
+++ b/src/jp_range/parser.py
@@ -331,4 +331,11 @@ def parse_jp_range(text: str) -> Interval:
             combined = combined.intersect(iv)
         return combined
 
+    # Try concatenated expressions without delimiters (e.g. "30以下20以上")
+    for i in range(1, len(text)):
+        left = _parse_atomic(text[:i])
+        right = _parse_atomic(text[i:])
+        if left is not None and right is not None:
+            return left.intersect(right)
+
     return None

--- a/tests/test_interval.py
+++ b/tests/test_interval.py
@@ -184,6 +184,22 @@ def test_gt_with_small_mixed():
     assert not r.lower_inclusive
 
 
+def test_reverse_upper_lower():
+    r = parse_jp_range("30以下20以上")
+    assert r.lower == 20
+    assert r.upper == 30
+    assert r.lower_inclusive is True
+    assert r.upper_inclusive is True
+
+
+def test_reverse_min_max():
+    r = parse_jp_range("最小-5最大５０")
+    assert r.lower == -5
+    assert r.upper == 50
+    assert r.lower_inclusive is True
+    assert r.upper_inclusive is True
+
+
 def test_parse_failure_returns_none():
     r = parse_jp_range("unknown")
     assert r is None


### PR DESCRIPTION
## Summary
- support concatenated range clauses without delimiters
- test parsing of reversed upper/lower and min/max expressions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683e498bd98c83279acd93c1a6db4f7d