### PR TITLE
Add numeric split option to apply_parse

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ from jp_range import apply_parse
 s = Series(["20～30", "50超", "未満100"])
 result = apply_parse(s)
 # result is a Series of pandas.Interval objects
+
+# Expand columns into numeric min/max
+df = apply_parse(s.to_frame(name="range"), split_numeric=True)
+# df has columns "range_max" and "range_min"
 ```
 
 ### Supported expressions

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -1,4 +1,5 @@
 from pandas import Series, DataFrame, Interval as PdInterval
+import pandas as pd
 
 from jp_range import Interval, parse, parse_jp_range, apply_parse, detect_interval_columns
 
@@ -41,4 +42,15 @@ def test_detect_interval_columns():
     cols = detect_interval_columns(df, threshold=0.5)
     assert "a" in cols
     assert "b" not in cols
+
+
+def test_apply_parse_split_numeric():
+    df = DataFrame({"range": ["20～30", "50超"]})
+    result = apply_parse(df, split_numeric=True)
+    assert "range_max" in result.columns
+    assert "range_min" in result.columns
+    assert result.loc[0, "range_min"] == 20
+    assert result.loc[0, "range_max"] == 30
+    assert result.loc[1, "range_min"] == 50
+    assert pd.isna(result.loc[1, "range_max"])
 


### PR DESCRIPTION
## Summary
- extend `apply_parse` with `split_numeric` argument to output numeric min/max columns
- document new option in README
- add test for `split_numeric` behavior

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683e56592428832794624b7dfcb7f438