### PR TITLE
Prevent SKU parsing as ranges

### DIFF
--- a/tests/test_interval.py
+++ b/tests/test_interval.py
@@ -73,3 +73,10 @@ def test_to_pd_interval():
     assert pd_interval.left == 1
     assert pd_interval.right == 3
     assert pd_interval.closed == "left"
+
+
+def test_code_like_strings_are_rejected():
+    r = parse_jp_range("21K-0131")
+    assert r.is_empty()
+    r = parse_jp_range("AB12345")
+    assert r.is_empty()


### PR DESCRIPTION
## Summary
- add checks to avoid parsing product codes like `21K-0131`
- use unit whitelist, negative patterns and strict hyphen rules
- reject code-like strings in tests

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683ec4e29a38832798fffae7eee7b697