### PR TITLE
Ignore serial-number like strings

### DIFF
--- a/src/jp_range/parser.py
+++ b/src/jp_range/parser.py
@@ -227,6 +227,10 @@ def parse_jp_range(
 
     text = _normalize(text).strip()
 
+    # Ignore strings containing numbers with leading zeros (e.g. serial numbers)
+    if re.search(r'(?:^|[^0-9])0[0-9]+', text):
+        return Interval()
+
     result = _parse_atomic(text)
     if result is not None:
         return result

--- a/tests/test_interval.py
+++ b/tests/test_interval.py
@@ -73,3 +73,8 @@ def test_to_pd_interval():
     assert pd_interval.left == 1
     assert pd_interval.right == 3
     assert pd_interval.closed == "left"
+
+
+def test_ignore_serial_number_like_strings():
+    r = parse_jp_range("21K-0131")
+    assert r.is_empty()


### PR DESCRIPTION
## Summary
- ignore numbers with leading zeros in parser
- add a regression test for serial number parsing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683ec8b715a48327853733c5f26f61e3