### PR TITLE
Support reversed range order

### DIFF
--- a/src/jp_range/parser.py
+++ b/src/jp_range/parser.py
@@ -79,6 +79,20 @@ def _range_builder(
     return _build
 
 
+def _range_builder_rev(
+    lower_inclusive: bool, upper_inclusive: bool
+) -> Callable[[re.Match[str]], Interval]:
+    def _build(m: re.Match[str]) -> Interval:  # noqa: WPS430
+        return Interval(
+            lower=_f(m.group(2)),
+            upper=_f(m.group(1)),
+            lower_inclusive=lower_inclusive,
+            upper_inclusive=upper_inclusive,
+        )
+
+    return _build
+
+
 def _single_lower(inclusive: bool) -> Callable[[re.Match[str]], Interval]:
     def _build(m: re.Match[str]) -> Interval:  # noqa: WPS430
         return Interval(
@@ -185,18 +199,30 @@ _PATTERNS: list[tuple[re.Pattern[str], Callable[[re.Match[str]], Interval]]] = [
     ),
     (re.compile(rf"^(?:最小(?:値)?|小){_NUM}{_SEP}{_NUM}未満$"), _min_lower_lt),
     (re.compile(rf"^(?:最小(?:値)?|小){_NUM}{_SEP}{_NUM}以下$"), _min_lower_le),
+    (re.compile(rf"^{_NUM}未満{_SEP}(?:最小(?:値)?|小){_NUM}$"), _range_builder_rev(True, False)),
+    (re.compile(rf"^{_NUM}以下{_SEP}(?:最小(?:値)?|小){_NUM}$"), _range_builder_rev(True, True)),
     (re.compile(rf"^(?:最大(?:値)?|大){_NUM}$"), _single_max),
     (re.compile(rf"^(?:最小(?:値)?|小){_NUM}$"), _single_min),
     (re.compile(rf"^{_NUM}以上{_SEP}{_NUM}以下$"), _range_builder(True, True)),
     (re.compile(rf"^{_NUM}以上{_SEP}{_NUM}未満$"), _range_builder(True, False)),
+    (re.compile(rf"^{_NUM}以下{_SEP}{_NUM}以上$"), _range_builder_rev(True, True)),
+    (re.compile(rf"^{_NUM}未満{_SEP}{_NUM}以上$"), _range_builder_rev(True, False)),
     (re.compile(rf"^{_NUM}超{_SEP}{_NUM}以下$"), _range_builder(False, True)),
     (re.compile(rf"^{_NUM}超{_SEP}{_NUM}未満$"), _range_builder(False, False)),
+    (re.compile(rf"^{_NUM}以下{_SEP}{_NUM}超$"), _range_builder_rev(False, True)),
+    (re.compile(rf"^{_NUM}未満{_SEP}{_NUM}超$"), _range_builder_rev(False, False)),
     (re.compile(rf"^{_NUM}を?超え{_SEP}{_NUM}以下$"), _range_builder(False, True)),
     (re.compile(rf"^{_NUM}を?超え{_SEP}{_NUM}未満$"), _range_builder(False, False)),
+    (re.compile(rf"^{_NUM}以下{_SEP}{_NUM}を?超え$"), _range_builder_rev(False, True)),
+    (re.compile(rf"^{_NUM}未満{_SEP}{_NUM}を?超え$"), _range_builder_rev(False, False)),
     (re.compile(rf"^{_NUM}を?上回り{_SEP}{_NUM}以下$"), _range_builder(False, True)),
     (re.compile(rf"^{_NUM}を?上回り{_SEP}{_NUM}未満$"), _range_builder(False, False)),
+    (re.compile(rf"^{_NUM}以下{_SEP}{_NUM}を?上回り$"), _range_builder_rev(False, True)),
+    (re.compile(rf"^{_NUM}未満{_SEP}{_NUM}を?上回り$"), _range_builder_rev(False, False)),
     (re.compile(rf"^{_NUM}より大きい{_SEP}{_NUM}以下$"), _range_builder(False, True)),
     (re.compile(rf"^{_NUM}より大きい{_SEP}{_NUM}未満$"), _range_builder(False, False)),
+    (re.compile(rf"^{_NUM}以下{_SEP}{_NUM}より大きい$"), _range_builder_rev(False, True)),
+    (re.compile(rf"^{_NUM}未満{_SEP}{_NUM}より大きい$"), _range_builder_rev(False, False)),
     (re.compile(rf"^{_NUM}(?:以上|以降|以後|から)$"), _single_lower(True)),
     (
         re.compile(rf"^{_NUM}(?:超|を?超える|より大きい|より上|を?上回る)$"),

--- a/tests/test_interval.py
+++ b/tests/test_interval.py
@@ -38,6 +38,8 @@ from jp_range import Interval, parse_jp_range
         ("１００より上、小10", 100, None, False, False, [], []),
         ("30以下20以上", 20, 30, True, True, [], []),
         ("最小-5最大５０", -5, 50, True, True, [], []),
+        ("30未満最小10", 10, 30, True, False, [], []),
+        ("20以下10より大きい", 10, 20, False, True, [], []),
     ],
 )
 def test_parse_ranges(text, lower, upper, lower_inc, upper_inc, contains, not_contains):


### PR DESCRIPTION
## Summary
- allow reversed-order expressions when specifying ranges
- test additional reversed cases

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684f6ba6d9e08327842c56a2565bf0c4